### PR TITLE
Fix prompt prefix when switching categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,8 @@
       }, 50);
 
       // Update prompt text for this cube and show the prompt toggle and label
-      promptArea.textContent = getPromptText(filename, activeCategory, activeCategory.currentIndex);
+      // Use the overall story index so prompts follow the full narrative
+      promptArea.textContent = getPromptText(filename, activeCategory, globalIndex);
       promptToggle.style.display = "block";
       promptLabel.style.display = "inline";
       promptArea.classList.remove("visible");


### PR DESCRIPTION
## Summary
- ensure prompts use global story index so "Then," appears for later cubes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f42c7e2288329af0c538e8689ec20